### PR TITLE
Adding python test resources. 

### DIFF
--- a/src/unittest/python/main_tests.py
+++ b/src/unittest/python/main_tests.py
@@ -3,14 +3,23 @@ from mockito import mock, verify
 import unittest
 
 from main import main_handler
+import test_utils
 
 
 class HelloWorldTest(unittest.TestCase):
     # all test methods should start with name "test_", else it will be ignored
-    @staticmethod
-    def test_main_should_issue_hello_world_message():
+    # all tests should have the below noinspection static clause to prevent
+    # test case may be static pylint errors with py tests.
+    # noinspection PyMethodMayBeStatic
+    def test_main_should_issue_hello_world_message(self):
         out = mock()
 
         main_handler(out)
 
         verify(out).write("Hello world from python module\n")
+
+    # noinspection PyMethodMayBeStatic
+    def test_should_load_json_test_resource(self):
+        json_test_resource_file_name = 'json_sample.json'
+        json_data = test_utils.load_json_test_resource(json_test_resource_file_name)
+        assert json_data['message'] == 'hello world'

--- a/src/unittest/python/module_example_tests.py
+++ b/src/unittest/python/module_example_tests.py
@@ -5,8 +5,8 @@ from module_example import hello_module
 
 
 class ModuleExampleTest(unittest.TestCase):
-    @staticmethod
-    def test_module_should_issue_hello_world_message():
+    # noinspection PyMethodMayBeStatic
+    def test_module_should_issue_hello_world_message(self):
         out = mock()
 
         hello_module(out)

--- a/src/unittest/python/test_utils.py
+++ b/src/unittest/python/test_utils.py
@@ -1,0 +1,16 @@
+import json
+import pathlib
+
+
+def _get_test_resource_file_path(file_name):
+    return pathlib.Path(__file__).parent.parent.absolute()\
+        .joinpath('test_resources')\
+        .joinpath(file_name)
+
+
+def load_json_test_resource(json_file_name):
+    file_path = _get_test_resource_file_path(json_file_name)
+    f = open(file_path, "r")
+    data = json.loads(f.read())
+    f.close()
+    return data

--- a/src/unittest/test_resources/json_sample.json
+++ b/src/unittest/test_resources/json_sample.json
@@ -1,0 +1,3 @@
+{
+  "message": "hello world"
+}


### PR DESCRIPTION
* unit test example with test resource
* For pycham/ide debug magic to work: prevent method could be static warning with py tests in pep8/pycharm/intellij. more details here: https://stackoverflow.com/questions/23554872/why-does-pycharm-propose-to-change-method-to-static